### PR TITLE
Feature/infra/modules

### DIFF
--- a/infrastructure/modules/natgw/main.tf
+++ b/infrastructure/modules/natgw/main.tf
@@ -1,0 +1,15 @@
+resource "aws_eip" "natgw" {
+  vpc = true
+  tags = {
+    Name = "NAT-Gateway-EIP-${var.public_subnet_id}"
+  }
+}
+
+resource "aws_nat_gateway" "natgw" {
+    allocation_id = aws_eip.natgw.id
+    subnet_id = var.public_subnet_id
+
+    tags = {
+      Name = "NAT-Gateway-${var.public_subnet_id}"
+    }
+}

--- a/infrastructure/modules/natgw/output.tf
+++ b/infrastructure/modules/natgw/output.tf
@@ -1,0 +1,4 @@
+output "aws_nat_gateway_id" {
+  value = aws_nat_gateway.natgw.id
+  description = "ID của NAT Gateway"
+}

--- a/infrastructure/modules/natgw/variable.tf
+++ b/infrastructure/modules/natgw/variable.tf
@@ -1,0 +1,5 @@
+variable "public_subnet_id" {
+  description = "Public subnet để đặt Nat Gateway"
+  type       = string
+
+}

--- a/infrastructure/modules/route_table/main.tf
+++ b/infrastructure/modules/route_table/main.tf
@@ -1,0 +1,29 @@
+resource "aws_route_table" "route_table" {
+  vpc_id = var.vpc_id
+  
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_route" "route_table" {
+  for_each = {
+    for idx, r in var.routes : idx => r
+  }
+
+  route_table_id = aws_route_table.route_table.id
+  destination_cidr_block = each.value.cidr_block
+  gateway_id = try(each.value.gateway_id, null)
+  nat_gateway_id = try(each.value.nat_gateway_id, null)
+  
+}
+
+
+resource "aws_route_table_association" "association" {
+  for_each = {
+    for idx, subnet_id in var.subnet_ids : idx => subnet_id
+  }
+
+  subnet_id      = each.value
+  route_table_id = aws_route_table.route_table.id
+}

--- a/infrastructure/modules/route_table/output.tf
+++ b/infrastructure/modules/route_table/output.tf
@@ -1,0 +1,5 @@
+output "route_table_ids" {
+  description = "List of route table IDs"
+  value       = aws_route_table.route_table.id
+  
+}

--- a/infrastructure/modules/route_table/variables.tf
+++ b/infrastructure/modules/route_table/variables.tf
@@ -1,0 +1,24 @@
+variable "vpc_id" {
+  description = "ID của VPC mà Route Tabble sễ được tạo."
+  type        = string
+}
+
+variable "routes" {
+  description = "Danh sách các route trong Route Table."
+  type = list(object({
+    cidr_block     = string
+    gateway_id     = optional(string)
+    nat_gateway_id = optional(string)
+  }))
+}
+
+variable "name" {
+  description = "Tên của Route Table muốn đặt."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Danh sách subnet muốn gắn vào Route Table."
+  type        = list(string)
+}
+

--- a/infrastructure/modules/security_group/main.tf
+++ b/infrastructure/modules/security_group/main.tf
@@ -1,0 +1,47 @@
+resource "aws_security_group" "this" {
+  name        = var.name
+  description = var.description
+  vpc_id      = var.vpc_id
+  tags        = merge({
+    Name = var.name
+  }, var.tags)
+
+}
+
+resource "aws_security_group_rule" "ingress" {
+  security_group_id = aws_security_group.this.id
+
+  for_each = {
+    for idx, rule in var.ingress_rules : idx => rule
+  }
+
+  type        = "ingress"
+  from_port   = each.value.from_port
+  to_port     = each.value.to_port
+  protocol    = each.value.protocol
+  description = try( each.value.description, null)
+  
+  cidr_blocks               = can(each.value.source_security_group_id) ? null : each.value.cidr_blocks
+  source_security_group_id = try(each.value.source_security_group_id, null)
+
+  depends_on  = [aws_security_group.this]
+}
+
+resource "aws_security_group_rule" "egress" {
+  security_group_id = aws_security_group.this.id
+
+  for_each = {
+    for idx, rule in var.egress_rules : idx => rule
+  }
+  type        = "egress"
+  from_port   = each.value.from_port
+  to_port     = each.value.to_port
+  protocol    = each.value.protocol
+  description = try(each.value.description, null)
+
+  cidr_blocks               = can(each.value.source_security_group_id) ? null : each.value.cidr_blocks
+  source_security_group_id = try(each.value.source_security_group_id, null)
+
+  depends_on = [aws_security_group.this]
+
+}

--- a/infrastructure/modules/security_group/output.tf
+++ b/infrastructure/modules/security_group/output.tf
@@ -1,0 +1,5 @@
+output "security_group_id" {
+  description = "ID của Security Group"
+  value       = aws_security_group.this.id
+  
+}

--- a/infrastructure/modules/security_group/variables.tf
+++ b/infrastructure/modules/security_group/variables.tf
@@ -1,0 +1,45 @@
+variable "name" {
+    description = "Tên của Security Group"
+    type = string
+}
+
+variable "description" {
+    description = "Mô tả của Security Group"
+    type = string
+  
+}
+
+variable "vpc_id" {
+    description = "ID của VPC mà Security Group sẽ được tạo trong đó"
+    type = string
+}
+
+variable "ingress_rules" {
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string 
+    cidr_blocks  = optional(list(string), []) 
+    source_security_group_id = optional(string) 
+    description = optional(string)
+  }))
+  default = []
+}
+
+variable "egress_rules" {
+  type = list(object({
+    from_port    = number
+    to_port      = number 
+    protocol     = string 
+    cidr_blocks  = optional(list(string), []) 
+    source_security_group_id = optional(string) 
+    description  = optional(string)
+  }))
+  default = []
+}
+
+variable "tags" {
+    description = "Tags cho Security Group"
+    type = map(string)
+    default = {}
+}

--- a/infrastructure/modules/vpc/main.tf
+++ b/infrastructure/modules/vpc/main.tf
@@ -1,0 +1,35 @@
+resource "aws_vpc" "this" {
+  cidr_block = var.cidr_block
+  
+  tags = {
+    Name = var.vpc-name
+  }
+}
+
+resource "aws_subnet" "public" {
+  for_each = toset(var.subnet_public_name)
+  
+  vpc_id   = aws_vpc.this.id
+  cidr_block = each.value
+  availability_zone = var.azs[index(var.subnet_public_name, each.value)]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.vpc-name}-public-${each.value}"
+  }
+
+}
+
+resource "aws_subnet" "private" {
+  for_each = toset(var.subnet_private_name)
+
+  vpc_id  = aws_vpc.this.id 
+  cidr_block = each.value 
+  availability_zone = var.azs[index(var.subnet_private_name, each.value)]
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "${var.vpc-name}-private-${each.value}"
+  }
+  
+}

--- a/infrastructure/modules/vpc/output.tf
+++ b/infrastructure/modules/vpc/output.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  value = [for subnet in aws_subnet.public : subnet.id]
+}
+
+output "private_subnet_ids" {
+    value = [for subnet in aws_subnet.private : subnet.id]
+}

--- a/infrastructure/modules/vpc/variables.tf
+++ b/infrastructure/modules/vpc/variables.tf
@@ -1,0 +1,28 @@
+variable "vpc-name" {
+  description = "Name of the VPC"
+  type        = string
+  default     = "vpc-default"
+}
+
+variable "cidr_block" {
+  description = "value of the CIDR block"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "subnet_public_name" {
+  description = "Name of the public subnet"
+  type        = list(string)
+  
+}
+
+variable "subnet_private_name" {
+  description = "Name of the private subnet"
+  type        = list(string)
+  
+}
+
+variable "azs" {
+  description = "value of the availability zones"
+  type        = list(string)
+}


### PR DESCRIPTION
# 🚀 Add: VPC Module (Terraform)

## 📌 Mô tả
Thêm module `vpc` dùng để triển khai hệ thống mạng ảo (VPC) trên nền tảng cloud (AWS/GCP), bao gồm:
- Tạo VPC với CIDR block cấu hình sẵn
- Tạo subnets (public/private) theo vùng (AZ)
- Thiết lập route tables và internet gateway
- Option: NAT Gateway, flow logs, DNS settings

## 🧱 Chi tiết thay đổi
- [x] `modules/vpc/main.tf` – Resource định nghĩa VPC, subnet, IGW, route tables
- [x] `modules/vpc/variables.tf` – Các biến như `cidr_block`, `azs`, `enable_nat`, v.v.
- [x] `modules/vpc/outputs.tf` – Xuất VPC ID, subnet IDs, IGW ID...
- [x] Thêm file example usage: `examples/vpc-basic/main.tf`

## ✅ Đã kiểm thử
- [x] Áp dụng thử trên môi trường dev (AWS)
- [x] `terraform validate` và `terraform fmt` passed
- [x] Kiểm tra log output, confirm tạo đủ tài nguyên

## 📝 Ghi chú
- Module này có thể mở rộng trong tương lai để hỗ trợ:
  - Flow logs
  - VPC peering
  - PrivateLink
- Có thể tích hợp vào CI/CD để validate config tự động

## 📎 Thông tin bổ sung
Liên quan issue/ticket: `#12`, `INFRA-304`

---

👨‍💻 Reviewer: @team-infra, @devops-lead  
📦 Ready for review & merge
